### PR TITLE
Updated set notation in argumento_principal.html

### DIFF
--- a/contenido/argumento_principal.html
+++ b/contenido/argumento_principal.html
@@ -160,7 +160,7 @@
             entonces
             <div class="scroll-wrapper">
                 \begin{eqnarray*}
-                \textbf{arg}(z)= \textbf{Arg}(z)+2n\pi, \quad n \in \mathbb Z.
+                \textbf{arg}(z)= \{ \textbf{Arg}(z)+2n\pi \mid n \in  \mathbb{Z} \}
                 \end{eqnarray*}
             </div>
             <p></p>


### PR DESCRIPTION
En la página https://complex-analysis.com/contenido/argumento_principal.html Indicas al principio que usas $\mathrm{arg}(z)$ para indicar el conjunto de todos los argumentos de $z$.

No obstante, aquí:

![image](https://github.com/complex-analysis/complex-analysis.github.io/assets/116151288/2eb93be8-807a-4e75-aaab-6a0804db263b)

hace una uso de una notación no estándar para indicar conjuntos al no introducirse entre llaves. He modificado la notación a $$\\{ \textbf{Arg}(z)+2n\pi \mid n \in  \mathbb{Z} \\},$$ añadiendo llaves ({}) ya que de esta manera se entiende mejor que es el **conjunto** de todos los argumentos principales tales que $n$ es un número entero.

Simplemente es una sugenrencia de notación para hacer más claro el texto. Un saludo y enhorabuena por el proyecto! 😄 

PD: el código al que me refiero es `\{\textbf{Arg}(z)+2n\pi \mid n \in  \mathbb{Z}\}` que no sé si Github está renderizando bien las llaves. En mi editor de mathjax funciona perfectamente...

EDIT: Ya he encontrado el fallo en porqué no renderizaba. Por lo visto hay que "escapar" con un '\' extra el propio '\' quedando así `\\{\textbf{Arg}(z)+2n\pi \mid n \in  \mathbb{Z}\\}`. Esto es por cómo está implementado en github... [Found here](https://github.com/orsharir/github-mathjax/issues/10)

