### PR TITLE
fixing typo in roots_complex_numbers.html

### DIFF
--- a/content/roots_complex_numbers.html
+++ b/content/roots_complex_numbers.html
@@ -227,7 +227,7 @@ nRoots = Sequence(r^(1/n) * exp( ί * ( theta/n + 2 * pi * k/n ) ), k, 0, n-1)
 
                 <p>
                     <strong>Exercise 2:</strong>
-                    Find the four roots of $z=1+i.$ You can check your results in the
+                    Find the fourth roots of $z=1+i.$ You can check your results in the
                     previous applets.
                 </p>
             </div>


### PR DESCRIPTION
It seemed unlikely you meant "with no particular nth specified, just find any four roots" so I assumed this was a typo and fixed it. Though perhaps this is a phrasing i just haven't seen (like saying the "three-roots" instead of "third roots"?)